### PR TITLE
Update puzzle to 10x10 and add solvable layout

### DIFF
--- a/StarBattle Complete/Models/Puzzle.swift
+++ b/StarBattle Complete/Models/Puzzle.swift
@@ -6,4 +6,26 @@ struct SamplePuzzle {
         [3,3,4,4,2],
         [3,4,4,4,2]
     ]
+
+    // 10x10 puzzle where each row acts as its own region. This keeps
+    // the example simple and guarantees that two stars per row, column
+    // and region are possible.
+    static let regions10x10: [[Int]] = (0..<10).map { row in
+        Array(repeating: row, count: 10)
+    }
+
+    /// Known star positions that solve `regions10x10`. Coordinates use
+    /// zero-based indexing.
+    static let solution10x10: [(Int, Int)] = [
+        (0,0), (0,2),
+        (1,4), (1,6),
+        (2,0), (2,2),
+        (3,4), (3,8),
+        (4,1), (4,6),
+        (5,3), (5,8),
+        (6,1), (6,5),
+        (7,7), (7,9),
+        (8,3), (8,5),
+        (9,7), (9,9)
+    ]
 }

--- a/StarBattle Complete/Views/GameView.swift
+++ b/StarBattle Complete/Views/GameView.swift
@@ -2,8 +2,10 @@ import SwiftUI
 
 struct GameView: View {
     @StateObject var viewModel = StarBattleViewModel(
-        gridSize: 5,
-        regions: SamplePuzzle.regions5x5
+        gridSize: 10,
+        regions: SamplePuzzle.regions10x10,
+        starsPerLine: 2,
+        starsPerRegion: 2
     )
 
     var body: some View {

--- a/StarBattle Complete/Views/GridView.swift
+++ b/StarBattle Complete/Views/GridView.swift
@@ -53,8 +53,10 @@ struct GridView_Previews: PreviewProvider {
         GridView()
             .environmentObject(
                 StarBattleViewModel(
-                    gridSize: 5,
-                    regions: SamplePuzzle.regions5x5
+                    gridSize: 10,
+                    regions: SamplePuzzle.regions10x10,
+                    starsPerLine: 2,
+                    starsPerRegion: 2
                 )
             )
             .previewLayout(.sizeThatFits)

--- a/StarBattle CompleteTests/StarBattle_CompleteTests.swift
+++ b/StarBattle CompleteTests/StarBattle_CompleteTests.swift
@@ -10,8 +10,19 @@ import Testing
 
 struct StarBattle_CompleteTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func puzzleSolvable() async throws {
+        let viewModel = StarBattleViewModel(
+            gridSize: 10,
+            regions: SamplePuzzle.regions10x10,
+            starsPerLine: 2,
+            starsPerRegion: 2
+        )
+
+        for (row, col) in SamplePuzzle.solution10x10 {
+            viewModel.grid[row][col] = .star
+        }
+
+        #expect(viewModel.isSolved())
     }
 
 }


### PR DESCRIPTION
## Summary
- upgrade puzzle grid to 10x10 with per‑row regions
- provide known solution for the puzzle
- update `GameView` and preview to use the bigger grid
- add a unit test verifying the puzzle's solvability

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684965af667c8330b94e3334abf09350