### PR TITLE
Add random puzzle generation and confetti

### DIFF
--- a/StarBattle Complete/Models/Puzzle.swift
+++ b/StarBattle Complete/Models/Puzzle.swift
@@ -1,21 +1,12 @@
+struct Puzzle {
+    let gridSize: Int
+    let regions: [[Int]]
+    let starsPerLine: Int
+    let starsPerRegion: Int
+    let solution: [(Int, Int)]
+}
+
 struct SamplePuzzle {
-    static let regions5x5: [[Int]] = [
-        [0,0,1,1,2],
-        [0,0,1,1,2],
-        [3,3,3,4,2],
-        [3,3,4,4,2],
-        [3,4,4,4,2]
-    ]
-
-    // 10x10 puzzle where each row acts as its own region. This keeps
-    // the example simple and guarantees that two stars per row, column
-    // and region are possible.
-    static let regions10x10: [[Int]] = (0..<10).map { row in
-        Array(repeating: row, count: 10)
-    }
-
-    /// Known star positions that solve `regions10x10`. Coordinates use
-    /// zero-based indexing.
     static let solution10x10: [(Int, Int)] = [
         (0,0), (0,2),
         (1,4), (1,6),
@@ -28,4 +19,87 @@ struct SamplePuzzle {
         (8,3), (8,5),
         (9,7), (9,9)
     ]
+
+    /// Generates random regions for the 10x10 puzzle while keeping
+    /// the star solution valid.
+    static func randomPuzzle() -> Puzzle {
+        let gridSize = 10
+        let starPairs: [[(Int, Int)]] = stride(from: 0, to: solution10x10.count, by: 2).map {
+            [solution10x10[$0], solution10x10[$0 + 1]]
+        }
+        let regions = generateRegions(gridSize: gridSize, starPairs: starPairs, cellsPerRegion: 10)
+        return Puzzle(gridSize: gridSize,
+                      regions: regions,
+                      starsPerLine: 2,
+                      starsPerRegion: 2,
+                      solution: solution10x10)
+    }
+
+    /// Expands each star pair into a contiguous region of `cellsPerRegion`
+    /// cells using a randomized flood fill.
+    private static func generateRegions(gridSize: Int,
+                                        starPairs: [[(Int, Int)]],
+                                        cellsPerRegion: Int) -> [[Int]] {
+        var regions = Array(repeating: Array(repeating: -1, count: gridSize), count: gridSize)
+        var queues: [[(Int, Int)]] = Array(repeating: [], count: starPairs.count)
+        var counts = Array(repeating: 0, count: starPairs.count)
+
+        for (index, pair) in starPairs.enumerated() {
+            for cell in pair {
+                regions[cell.0][cell.1] = index
+                queues[index].append(cell)
+                counts[index] += 1
+            }
+        }
+
+        let moves = [(1,0), (-1,0), (0,1), (0,-1)]
+        while counts.contains(where: { $0 < cellsPerRegion }) {
+            var progress = false
+            for i in 0..<starPairs.count {
+                guard counts[i] < cellsPerRegion else { continue }
+                var nextQueue: [(Int, Int)] = []
+
+                for cell in queues[i] {
+                    guard counts[i] < cellsPerRegion else {
+                        nextQueue.append(cell)
+                        continue
+                    }
+
+                    var shuffledMoves = moves.shuffled()
+                    let r = cell.0
+                    let c = cell.1
+                    while !shuffledMoves.isEmpty && counts[i] < cellsPerRegion {
+                        let move = shuffledMoves.removeFirst()
+                        let nr = r + move.0
+                        let nc = c + move.1
+                        if nr >= 0 && nr < gridSize && nc >= 0 && nc < gridSize && regions[nr][nc] == -1 {
+                            regions[nr][nc] = i
+                            nextQueue.append((nr, nc))
+                            counts[i] += 1
+                            progress = true
+                        }
+                    }
+
+                    if counts[i] < cellsPerRegion {
+                        nextQueue.append(cell)
+                    }
+                }
+
+                queues[i] = nextQueue
+            }
+
+            if !progress {
+                // If no region could expand, assign a random remaining cell
+                if let r = (0..<gridSize).first(where: { row in regions[row].contains(-1) }),
+                   let c = regions[r].firstIndex(of: -1) {
+                    let target = counts.firstIndex(of: counts.min() ?? 0) ?? 0
+                    regions[r][c] = target
+                    queues[target].append((r, c))
+                    counts[target] += 1
+                }
+            }
+        }
+
+        return regions
+    }
 }

--- a/StarBattle Complete/ViewModels/StarBattleViewModel.swift
+++ b/StarBattle Complete/ViewModels/StarBattleViewModel.swift
@@ -7,15 +7,12 @@ class StarBattleViewModel: ObservableObject {
     let starsPerLine: Int
     let starsPerRegion: Int
 
-    init(gridSize: Int,
-         regions: [[Int]],
-         starsPerLine: Int = 2,
-         starsPerRegion: Int = 1) {
-        self.gridSize = gridSize
-        self.regions = regions
-        self.starsPerLine = starsPerLine
-        self.starsPerRegion = starsPerRegion
-        self.grid = Array(repeating: Array(repeating: .empty, count: gridSize), count: gridSize)
+    init(puzzle: Puzzle) {
+        self.gridSize = puzzle.gridSize
+        self.regions = puzzle.regions
+        self.starsPerLine = puzzle.starsPerLine
+        self.starsPerRegion = puzzle.starsPerRegion
+        self.grid = Array(repeating: Array(repeating: .empty, count: puzzle.gridSize), count: puzzle.gridSize)
     }
 
     func placeStar(atRow row: Int, column: Int) {

--- a/StarBattle Complete/Views/ConfettiView.swift
+++ b/StarBattle Complete/Views/ConfettiView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import UIKit
+
+struct ConfettiView: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: .zero)
+        let emitter = CAEmitterLayer()
+        emitter.emitterPosition = CGPoint(x: UIScreen.main.bounds.width / 2, y: -10)
+        emitter.emitterShape = .line
+        emitter.emitterSize = CGSize(width: UIScreen.main.bounds.width, height: 2)
+
+        var cells: [CAEmitterCell] = []
+        let colors: [UIColor] = [.systemRed, .systemBlue, .systemGreen, .systemOrange, .systemPurple]
+        for color in colors {
+            let cell = CAEmitterCell()
+            cell.birthRate = 4
+            cell.lifetime = 7.0
+            cell.velocity = 200
+            cell.velocityRange = 50
+            cell.emissionLongitude = .pi
+            cell.spinRange = 4
+            cell.scale = 0.05
+            cell.scaleRange = 0.02
+            cell.color = color.cgColor
+            cell.contents = UIImage(systemName: "circle.fill")?.cgImage
+            cells.append(cell)
+        }
+
+        emitter.emitterCells = cells
+        view.layer.addSublayer(emitter)
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}

--- a/StarBattle Complete/Views/GameView.swift
+++ b/StarBattle Complete/Views/GameView.swift
@@ -1,37 +1,43 @@
 import SwiftUI
 
 struct GameView: View {
-    @StateObject var viewModel = StarBattleViewModel(
-        gridSize: 10,
-        regions: SamplePuzzle.regions10x10,
-        starsPerLine: 2,
-        starsPerRegion: 2
-    )
+    @StateObject private var viewModel: StarBattleViewModel
+
+    init() {
+        let puzzle = SamplePuzzle.randomPuzzle()
+        _viewModel = StateObject(wrappedValue: StarBattleViewModel(puzzle: puzzle))
+    }
 
     var body: some View {
-        VStack {
-            Text("Game Screen")
-                .font(.title)
-                .padding()
-
-            GridView()
-                .environmentObject(viewModel)
-                .padding()
-
-            Button(action: {
-                viewModel.resetGrid()
-            }) {
-                Text("Reset")
+        ZStack {
+            VStack {
+                Text("Game Screen")
+                    .font(.title)
                     .padding()
-                    .background(Color.red)
-                    .foregroundColor(.white)
-                    .cornerRadius(8)
+
+                GridView()
+                    .environmentObject(viewModel)
+                    .padding()
+
+                Button(action: {
+                    viewModel.resetGrid()
+                }) {
+                    Text("Reset")
+                        .padding()
+                        .background(Color.red)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+
+                if viewModel.isSolved() {
+                    Text("Puzzle solved!")
+                        .foregroundColor(.green)
+                        .padding()
+                }
             }
-
             if viewModel.isSolved() {
-                Text("Puzzle solved!")
-                    .foregroundColor(.green)
-                    .padding()
+                ConfettiView()
+                    .ignoresSafeArea()
             }
         }
         .navigationTitle("Star Battle")


### PR DESCRIPTION
## Summary
- generate random contiguous regions for the 10x10 puzzle
- initialize the game with a random puzzle
- show animated confetti when the puzzle is solved

## Testing
- `swift -v`

------
https://chatgpt.com/codex/tasks/task_e_684967db4ae483308af6be363a2f5587